### PR TITLE
Allow passing `loose` and `useBuiltIns` options to `babel-preset-env`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
+.idea
+*.iml
 node_modules
 package-lock.json
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+# babel-preset-wix
+
+This plugins combines some commonly used Babel presets ans plugins.
+
+Presets:
+
+* babel-preset-env
+* babel-preset-react
+* babel-preset-stage-2
+
+Plugins:
+
+* babel-plugin-syntax-dynamic-import
+* babel-plugin-transform-decorators-legacy
+* babel-plugin-transform-dynamic-import _(testing environment only)_
+
+## Installation
+
+```bash
+npm install --save babel-preset-wix
+```
+
+## Usage
+
+To use `babel-preset-wix` your `.babelrc` file should look like this
+
+```json
+{"presets": ["wix"]}
+```
+
+### ES Modules
+
+By default `babel-preset-wix` compiles modules to commonjs format.
+
+if you want to skip module compilation and keep imports/exports, you can add `module` property to your `package.json` file.
+
+```json
+{
+  "module": "dist/src/index.js"
+}
+```
+
+### Loose mode
+
+There's also a *loose* flavour of this plugin, which enables `loose` and `useBuiltIns` options of `babel-preset-env`.
+
+```json
+{"presets": ["wix/loose"]}
+```

--- a/index.js
+++ b/index.js
@@ -4,8 +4,29 @@ const basePresets = ['react', 'stage-2'];
 const basePlugins = ['transform-decorators-legacy', 'syntax-dynamic-import'];
 const testPlugins = env === 'test' ? ['dynamic-import-node'] : [];
 const pkg = require(path.resolve('package.json'));
-const modules = process.env.IN_WEBPACK === 'true' || pkg.module ? false : 'commonjs';
-const envPreset = env === 'test' ? ['env', {targets: {node: 'current'}, modules}] : ['env', {modules}];
-const presets = [envPreset].concat(basePresets);
-const plugins = basePlugins.concat(testPlugins);
-module.exports = {presets, plugins};
+
+function buildPreset(context, opts = {}) {
+  const envPresetOptions = {};
+  envPresetOptions.modules = process.env.IN_WEBPACK === 'true' || pkg.module ? false : 'commonjs';
+  if (typeof opts.loose !== 'undefined') {
+    envPresetOptions.loose = opts.loose;
+  }
+  if (typeof opts.useBuiltIns !== 'undefined') {
+    envPresetOptions.useBuiltIns = opts.useBuiltIns;
+  }
+  const envPreset = env === 'test' ?
+    ['env', Object.assign({targets: {node: 'current'}}, envPresetOptions)] :
+    ['env', envPresetOptions];
+  const presets = [envPreset].concat(basePresets);
+  const plugins = basePlugins.concat(testPlugins);
+  return {presets, plugins};
+}
+
+module.exports = buildPreset({});
+
+Object.defineProperty(module.exports, 'buildPreset', {
+  configurable: true,
+  writable: true,
+  enumerable: false,
+  value: buildPreset
+});

--- a/loose.js
+++ b/loose.js
@@ -1,0 +1,2 @@
+const buildPreset = require('./index').buildPreset;
+module.exports = buildPreset({loose: true, useBuiltIns: true});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Shared babel config for all Wix projects",
   "main": "index.js",
   "files": [
-    "index.js"
+    "index.js",
+    "loose.js"
   ],
   "scripts": {
     "test": "mocha --reporter mocha-env-reporter",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-preset-wix",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Shared babel config for all Wix projects",
   "homepage": "https://github.com/wix/babel-preset-wix",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "babel-preset-wix",
   "version": "2.0.0",
   "description": "Shared babel config for all Wix projects",
+  "homepage": "https://github.com/wix/babel-preset-wix",
   "main": "index.js",
   "files": [
     "index.js",
@@ -14,6 +15,10 @@
   },
   "author": "Shahar Talmi",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com/wix/babel-preset-wix.git"
+  },
   "eslintConfig": {
     "extends": "wix/esnext"
   },

--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "eslint-config-wix": "^1.1.16",
     "mocha": "^4.0.1",
     "mocha-env-reporter": "^3.0.0",
-    "wnpm-ci": "^6.2.52"
+    "wnpm-ci": "^7.0.1"
   }
 }


### PR DESCRIPTION
This pull-request covers a couple of things:

- Exposes `loose` and `useBuiltIns` options
- Adds another preset with both options on
- Adds a README file with basic usage info

The main purpose of `loose` mode is to allow for smaller bundle size.
