### PR TITLE
Use `dynamic-import-node` plugin instead of `transform-dynamic-import`

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const path = require('path');
 const env = process.env.BABEL_ENV || process.env.NODE_ENV;
 const basePresets = ['react', 'stage-2'];
 const basePlugins = ['transform-decorators-legacy', 'syntax-dynamic-import'];
-const testPlugins = env === 'test' ? ['transform-dynamic-import'] : [];
+const testPlugins = env === 'test' ? ['dynamic-import-node'] : [];
 const pkg = require(path.resolve('package.json'));
 const modules = process.env.IN_WEBPACK === 'true' || pkg.module ? false : 'commonjs';
 const envPreset = env === 'test' ? ['env', {targets: {node: 'current'}, modules}] : ['env', {modules}];

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
-    "babel-plugin-transform-dynamic-import": "^2.0.0",
+    "babel-plugin-dynamic-import-node": "^2.1.0",
     "babel-preset-env": "^1.6.0",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1"


### PR DESCRIPTION
`babel-plugin-transform-dynamic-import` is a babel 7 plugin, while others are babel 6.

Using `babel-plugin-dynamic-import-node` eliminates npm warnings during install.